### PR TITLE
Use driver i2c_master header

### DIFF
--- a/v2SpeechEnhancer/components/is31fl3216_custom/include/is31fl3216_custom.h
+++ b/v2SpeechEnhancer/components/is31fl3216_custom/include/is31fl3216_custom.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "esp_driver/i2c_master.h"
+#include "driver/i2c_master.h"
 #include "esp_err.h"
 #include <stdint.h>
 

--- a/v2SpeechEnhancer/components/is31fl3216_custom/is31fl3216_custom.c
+++ b/v2SpeechEnhancer/components/is31fl3216_custom/is31fl3216_custom.c
@@ -1,5 +1,5 @@
 #include "is31fl3216_custom.h"
-#include "esp_driver/i2c_master.h"
+#include "driver/i2c_master.h"
 #include "esp_log.h"
 #include "esp_check.h"
 #include <string.h>   // for memcpy

--- a/v2SpeechEnhancer/main/main.c
+++ b/v2SpeechEnhancer/main/main.c
@@ -23,7 +23,7 @@
 #include "esp_err.h"
 
 #include "driver/gpio.h"
-#include "esp_driver/i2c_master.h"
+#include "driver/i2c_master.h"
 #include "driver/i2s_std.h"
 #include "esp_heap_caps.h"
 #include "soc/clk_tree_defs.h"


### PR DESCRIPTION
## Summary
- include the ESP-IDF v5 `driver/i2c_master.h` header in the custom IS31FL3216 component
- update main to include the new I2C master driver path

## Testing
- not run (ESP-IDF tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cdeb704368833094458cdd8ae34074