### PR TITLE
Include FreeRTOS headers in IS31FL3216 driver

### DIFF
--- a/v2SpeechEnhancer/components/is31fl3216_custom/is31fl3216_custom.c
+++ b/v2SpeechEnhancer/components/is31fl3216_custom/is31fl3216_custom.c
@@ -2,6 +2,8 @@
 #include "driver/i2c_master.h"
 #include "esp_log.h"
 #include "esp_check.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 #include <string.h>   // for memcpy
 #include <inttypes.h> // for PRIu32 in logging
 #include "soc/clk_tree_defs.h"


### PR DESCRIPTION
## Summary
- include the FreeRTOS headers so vTaskDelay and pdMS_TO_TICKS are declared in the IS31FL3216 driver

## Testing
- `idf.py build` *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdf4aec39c8330818d11b8e64c63b9